### PR TITLE
Move properties-processing logic to specific implementations

### DIFF
--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/PropertyProcessorContract.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/PropertyProcessorContract.java
@@ -1,3 +1,19 @@
+// This file is part of teams, licensed under the GNU License.
+//
+// Copyright (c) 2024-2025 aivruu
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package io.github.aivruu.teams.tag.application.modification.property;
 
 import io.github.aivruu.teams.tag.application.modification.ModificationContext;

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/PropertyProcessorContract.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/PropertyProcessorContract.java
@@ -1,0 +1,37 @@
+package io.github.aivruu.teams.tag.application.modification.property;
+
+import io.github.aivruu.teams.tag.application.modification.ModificationContext;
+import io.github.aivruu.teams.tag.domain.TagPropertiesValueObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An interface-contract that defines the methods required for tag-properties processing.
+ *
+ * @param <T> the property's type.
+ * @since 4.1.0
+ */
+public interface PropertyProcessorContract<T> {
+  /**
+   * Returns the context of the modification for this property.
+   *
+   * @return The {@link ModificationContext} for the property.
+   * @since 4.1.0
+   */
+  @NotNull ModificationContext context();
+
+  /**
+   * Handles the processing-logic for the specified tag-property with the given input.
+   *
+   * @param input      the input for the property.
+   * @param properties the current properties of the tag.
+   * @param oldValue   the old-value for the property.
+   * @return A new {@link TagPropertiesValueObject} or {@code null} if the property was not
+   * modified, or is the same as the old value.
+   * @since 4.1.0
+   */
+  @Nullable TagPropertiesValueObject handle(
+     final @NotNull String input,
+     final @NotNull TagPropertiesValueObject properties,
+     final @Nullable T oldValue);
+}

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/ColorPropertyProcessor.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/ColorPropertyProcessor.java
@@ -1,0 +1,30 @@
+package io.github.aivruu.teams.tag.application.modification.property.type;
+
+import io.github.aivruu.teams.tag.application.modification.ModificationContext;
+import io.github.aivruu.teams.tag.application.modification.property.PropertyProcessorContract;
+import io.github.aivruu.teams.tag.domain.TagPropertiesValueObject;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+
+public enum ColorPropertyProcessor implements PropertyProcessorContract<NamedTextColor> {
+  INSTANCE;
+
+  @Override
+  public @NotNull ModificationContext context() {
+    return ModificationContext.COLOR;
+  }
+
+  @Override
+  public @Nullable TagPropertiesValueObject handle(
+     final @NotNull String input,
+     final @NotNull TagPropertiesValueObject properties,
+     final @Nullable NamedTextColor oldValue) {
+    final NamedTextColor newColor = NamedTextColor.NAMES.value(input.toLowerCase(Locale.ROOT));
+    return (newColor != null)
+       ? new TagPropertiesValueObject(properties.prefix(), properties.suffix(), newColor)
+       : null;
+  }
+}

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/ColorPropertyProcessor.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/ColorPropertyProcessor.java
@@ -1,3 +1,19 @@
+// This file is part of teams, licensed under the GNU License.
+//
+// Copyright (c) 2024-2025 aivruu
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package io.github.aivruu.teams.tag.application.modification.property.type;
 
 import io.github.aivruu.teams.tag.application.modification.ModificationContext;

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/PrefixPropertyProcessor.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/PrefixPropertyProcessor.java
@@ -1,0 +1,36 @@
+package io.github.aivruu.teams.tag.application.modification.property.type;
+
+import io.github.aivruu.teams.tag.application.modification.ModificationContext;
+import io.github.aivruu.teams.tag.application.modification.property.PropertyProcessorContract;
+import io.github.aivruu.teams.tag.domain.TagPropertiesValueObject;
+import io.github.aivruu.teams.util.application.component.MiniMessageParser;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public enum PrefixPropertyProcessor implements PropertyProcessorContract<Component> {
+  INSTANCE;
+
+  @Override
+  public @NotNull ModificationContext context() {
+    return ModificationContext.PREFIX;
+  }
+
+  @Override
+  public @Nullable TagPropertiesValueObject handle(
+     final @NotNull String input,
+     final @NotNull TagPropertiesValueObject properties,
+     final @Nullable Component oldValue) {
+    final boolean clear = input.equalsIgnoreCase("clear");
+    if (clear && oldValue == null) {
+      return null;
+    }
+    Component newPrefix = null;
+    if (!clear) {
+      newPrefix = MiniMessageParser.text(input);
+    }
+    return (newPrefix != null && newPrefix.equals(oldValue))
+       ? null
+       : new TagPropertiesValueObject(newPrefix, properties.suffix(), properties.color());
+  }
+}

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/PrefixPropertyProcessor.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/PrefixPropertyProcessor.java
@@ -1,3 +1,19 @@
+// This file is part of teams, licensed under the GNU License.
+//
+// Copyright (c) 2024-2025 aivruu
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package io.github.aivruu.teams.tag.application.modification.property.type;
 
 import io.github.aivruu.teams.tag.application.modification.ModificationContext;

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/SuffixPropertyProcessor.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/SuffixPropertyProcessor.java
@@ -1,0 +1,36 @@
+package io.github.aivruu.teams.tag.application.modification.property.type;
+
+import io.github.aivruu.teams.tag.application.modification.ModificationContext;
+import io.github.aivruu.teams.tag.application.modification.property.PropertyProcessorContract;
+import io.github.aivruu.teams.tag.domain.TagPropertiesValueObject;
+import io.github.aivruu.teams.util.application.component.MiniMessageParser;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public enum SuffixPropertyProcessor implements PropertyProcessorContract<Component> {
+  INSTANCE;
+
+  @Override
+  public @NotNull ModificationContext context() {
+    return ModificationContext.SUFFIX;
+  }
+
+  @Override
+  public @Nullable TagPropertiesValueObject handle(
+     final @NotNull String input,
+     final @NotNull TagPropertiesValueObject properties,
+     final @Nullable Component oldValue) {
+    final boolean clear = input.equalsIgnoreCase("clear");
+    if (clear && oldValue == null) {
+      return null;
+    }
+    Component newSuffix = null;
+    if (!clear) {
+      newSuffix = MiniMessageParser.text(input);
+    }
+    return (newSuffix != null && newSuffix.equals(oldValue))
+       ? null
+       : new TagPropertiesValueObject(properties.prefix(), newSuffix, properties.color());
+  }
+}

--- a/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/SuffixPropertyProcessor.java
+++ b/api/src/main/java/io/github/aivruu/teams/tag/application/modification/property/type/SuffixPropertyProcessor.java
@@ -1,3 +1,19 @@
+// This file is part of teams, licensed under the GNU License.
+//
+// Copyright (c) 2024-2025 aivruu
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
 package io.github.aivruu.teams.tag.application.modification.property.type;
 
 import io.github.aivruu.teams.tag.application.modification.ModificationContext;

--- a/plugin/src/main/java/io/github/aivruu/teams/tag/application/listener/TagModificationChatInputListener.java
+++ b/plugin/src/main/java/io/github/aivruu/teams/tag/application/listener/TagModificationChatInputListener.java
@@ -46,11 +46,14 @@ public final class TagModificationChatInputListener implements Listener {
       return;
     }
     event.setCancelled(true);
-    // Delegate input-processing logic for validation before actual tag's property-modification.
-    //
-    // And ignore boolean-result as process-notifying for the player is made by the processor's
-    // implementation.
+    /*
+     * Delegate input-processing to processor which will decide what implementation assign for the
+     * input.
+     *
+     * And we ignore the result as the notifications about the process are handled by an
+     * implementation of the processor.
+     */
     this.tagModificationProcessor.process(player, modification,
-       PlainComponentParser.plain(event.message()));
+       PlainComponentParser.plain(event.message()).replace("\"", ""));
   }
 }

--- a/plugin/src/main/java/io/github/aivruu/teams/tag/infrastructure/modification/TagModificationCacheRepository.java
+++ b/plugin/src/main/java/io/github/aivruu/teams/tag/infrastructure/modification/TagModificationCacheRepository.java
@@ -42,7 +42,7 @@ public final class TagModificationCacheRepository implements TagModificationRepo
       return;
     }
     this.cache = Caffeine.newBuilder()
-       .expireAfterWrite(15, TimeUnit.SECONDS)
+       .expireAfterWrite(30, TimeUnit.SECONDS)
        .scheduler(Scheduler.systemScheduler())
        .removalListener(new TagModificationCacheInvalidationListener(configurationManager))
        .build();


### PR DESCRIPTION
The few changes of this PR are for the Tags-Edition aspect, which moves the logic used to process the input into a value for the specific-property selected, to implementations for each kind of property.

## Features
* Moved input-processing logic to specific-implementations depending on property-type.
* Improved readability and reduced amount of code at the `TagModificationProcessorImpl` class.
* Now spaces in the input are considered directly at the `AsyncChatEvent`'s listener, removing concatenation for the `Component` type-properties.